### PR TITLE
Fix a bug, where ksort return value is being misused in return statement

### DIFF
--- a/src/app/code/community/Smile/MongoCatalog/Model/Resource/Override/Catalog/Layer/Filter/Attribute.php
+++ b/src/app/code/community/Smile/MongoCatalog/Model/Resource/Override/Catalog/Layer/Filter/Attribute.php
@@ -129,6 +129,7 @@ class Smile_MongoCatalog_Model_Resource_Override_Catalog_Layer_Filter_Attribute
             }
         }
 
-        return ksort($aggregationResult);
+        ksort($aggregationResult);
+        return $aggregationResult;
     }
 }


### PR DESCRIPTION
According to http://php.net/manual/en/function.ksort.php - ksort return value is a bool, the method signature expects an array instead. This fixes a problem with layered navigation not being displayed.